### PR TITLE
carrier waveをつかって画像をアップロード

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Ignore bundler config.
 /.bundle
 /vendor/bundle
+/public/uploads
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'rails-controller-testing'
 gem 'factory_girl_rails', '~> 4.4.1'
 
 gem 'devise'
+
+gem 'carrierwave', '>= 1.0.0.beta', '< 2.0'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (9.0.6)
+    carrierwave (1.0.0.beta)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -219,6 +223,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave (>= 1.0.0.beta, < 2.0)
   coffee-rails (~> 4.1.0)
   devise
   factory_girl_rails (~> 4.4.1)

--- a/app/assets/javascripts/new-message.js
+++ b/app/assets/javascripts/new-message.js
@@ -15,7 +15,7 @@ function insertHtml(data) {
 $(function() {
   $('#message-form').on('submit', function(e) {
       e.preventDefault();
-      var form = $('#message-form').get()[0];
+      var form = $(this).get()[0];
 
       var formData = new FormData(form);
 

--- a/app/assets/javascripts/new-message.js
+++ b/app/assets/javascripts/new-message.js
@@ -25,9 +25,6 @@ $(function() {
         type: 'POST',
         datatype: 'json',
         data:  formData,
-            // body: $(this).find('#message_body').prop('value'),
-            // image: $(this).find('#message_image').prop('value'),
-            // group_id: $(this).find('#message_group_id').prop('value'),
         processData: false,
         contentType: false
       })

--- a/app/assets/javascripts/new-message.js
+++ b/app/assets/javascripts/new-message.js
@@ -1,22 +1,35 @@
 // jsonで飛んできたメッセージのhtmlを生成して追加する
 function insertHtml(data) {
-  var html = "<div class= 'message__header clearfix'><div class='message__header__name'>"+data.name+"</div><div class='message__header__date'>"+data.date+"</div></div><div class='message__body'>"+data.body+"</div>";
+  var html = "<div class= 'message__header clearfix'>\
+                <div class='message__header__name'>"+data.name+"</div>\
+                <div class='message__header__date'>"+data.date+"</div>\
+              </div>\
+              <div class='message__body'>\
+                <p>"+data.body+"</p>\
+                <img src="+data.image.url+"/>\
+              </div>";
+
   $('#ajax').append(html);
 };
 
 $(function() {
   $('#message-form').on('submit', function(e) {
       e.preventDefault();
+      var form = $('#message-form').get()[0];
+
+      var formData = new FormData(form);
+
+      // ajaxで送信
       $.ajax({
         url: 'http://localhost:3000/messages.json',
         type: 'POST',
         datatype: 'json',
-        data: {
-          message: {
-            body: $(this).find('#message_body').prop('value'),
-            group_id: $(this).find('#message_group_id').prop('value'),
-          }
-        }
+        data:  formData,
+            // body: $(this).find('#message_body').prop('value'),
+            // image: $(this).find('#message_image').prop('value'),
+            // group_id: $(this).find('#message_group_id').prop('value'),
+        processData: false,
+        contentType: false
       })
       .done(function(data) {
         insertHtml(data);

--- a/app/assets/javascripts/new-message.js
+++ b/app/assets/javascripts/new-message.js
@@ -1,13 +1,23 @@
 // jsonで飛んできたメッセージのhtmlを生成して追加する
 function insertHtml(data) {
-  var html = "<div class= 'message__header clearfix'>\
-                <div class='message__header__name'>"+data.name+"</div>\
-                <div class='message__header__date'>"+data.date+"</div>\
-              </div>\
-              <div class='message__body'>\
-                <p>"+data.body+"</p>\
-                <img src="+data.image.url+"/>\
-              </div>";
+  if(data.image == null){
+    var html = "<div class= 'message__header clearfix'>\
+                  <div class='message__header__name'>"+data.name+"</div>\
+                  <div class='message__header__date'>"+data.date+"</div>\
+                </div>\
+                <div class='message__body'>\
+                  <p>"+data.body+"</p>\
+                </div>";
+  } else {
+    var html = "<div class= 'message__header clearfix'>\
+                  <div class='message__header__name'>"+data.name+"</div>\
+                  <div class='message__header__date'>"+data.date+"</div>\
+                </div>\
+                <div class='message__body'>\
+                  <p>"+data.body+"</p>\
+                  <img src="+data.image+"/>\
+                </div>";
+  }
 
   $('#ajax').append(html);
 };

--- a/app/assets/stylesheets/modules/_groups.scss
+++ b/app/assets/stylesheets/modules/_groups.scss
@@ -169,6 +169,10 @@ a {
         margin-top: 10px;
         font-size: 14px;
         color: #434A54;
+        img {
+          max-width: 300px;
+          max-height: 300px;
+        }
       }
     }
   }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,10 +5,11 @@ class MessagesController < ApplicationController
     respond_to do |format|
       if @message.save
         format.html { redirect_to group_url(current_group)}
-        format.json { render json: {
-          name: @message.user.name,
-          date: @message.created_at.strftime('%Y年%m月%d日 %H:%M'),
-          body: @message.body, }
+        format.json { render json: @message
+          # name: @message.user.name,
+          # date: @message.created_at.strftime('%Y年%m月%d日 %H:%M'),
+          # body: @message.body,
+          # image: @message.image
         }
       else
         flash[:errors] = @message.errors.full_messages
@@ -19,7 +20,6 @@ class MessagesController < ApplicationController
 
   private
     def message_params
-      binding.pry
       params.require(:message).permit(:body, :group_id, :image).merge(user_id: current_user.id)
     end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,14 @@ class MessagesController < ApplicationController
     respond_to do |format|
       if @message.save
         format.html { redirect_to group_url(current_group)}
-        format.json { render json: @message }
+        format.json { render json:
+          {
+          name: @message.user.name,
+          date: @message.created_at.strftime('%Y年%m月%d日 %H:%M'),
+          body: @message.body,
+          image: @message.image.url
+          }
+        }
       else
         flash[:errors] = @message.errors.messages
         format.html { redirect_to group_url(current_group) }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,7 @@ class MessagesController < ApplicationController
         format.html { redirect_to group_url(current_group)}
         format.json { render json: @message }
       else
-        flash[:errors] = @message.errors.full_messages
+        flash[:errors] = @message.errors.messages
         format.html { redirect_to group_url(current_group) }
         format.json { redirect_to group_url(current_group) }
       end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,15 +5,11 @@ class MessagesController < ApplicationController
     respond_to do |format|
       if @message.save
         format.html { redirect_to group_url(current_group)}
-        format.json { render json: @message
-          # name: @message.user.name,
-          # date: @message.created_at.strftime('%Y年%m月%d日 %H:%M'),
-          # body: @message.body,
-          # image: @message.image
-        }
+        format.json { render json: @message }
       else
         flash[:errors] = @message.errors.full_messages
-        format.html { redirect_to root_url }
+        format.html { redirect_to group_url(current_group) }
+        format.json { redirect_to group_url(current_group) }
       end
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,6 +19,7 @@ class MessagesController < ApplicationController
 
   private
     def message_params
-      params.require(:message).permit(:body, :group_id).merge(user_id: current_user.id)
+      binding.pry
+      params.require(:message).permit(:body, :group_id, :image).merge(user_id: current_user.id)
     end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,4 +5,7 @@ class Message < ApplicationRecord
 
   #validation
   validates :body, presence: true
+
+  #image uploader
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,9 +36,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -1,8 +1,9 @@
 .chat
   - if flash[:errors].present?
     .flash-error
-      - flash[:errors].each do |msg|
-        %p.error= msg
+      - flash[:errors].each do |key, msg|
+        - msg.each do |val|
+          %p.error= val
   - if flash[:success].present?
     .flash-success
       %p.success= flash[:success]

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -41,9 +41,9 @@
       .footer__chat
         = form_for(@message, html: {class: "message-form clearfix", id: "message-form"}, method: "post") do |f|
           .message-input
-            = f.text_area :body, class: "message-input__text"
+            = f.text_area :body, class: "message-input__text", id: "message_body"
             %label.image
               = fa_icon "image"
-              = f.file_field :image, class: "message-input__image"
+              = f.file_field :image, class: "message-input__image", id: "message_image"
             =f.hidden_field :group_id, value: params[:id]
           = f.submit value: "Send", class: "message-submit", data: {disable_with: "Send"}

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -12,7 +12,6 @@
       .user__edit
         =link_to new_group_path do
           =fa_icon "edit"
-        -# 暫定的に設定ボタンをログアウトボタンにしている
         =link_to edit_user_path(current_user) do
           =fa_icon "cog"
     %ul.groups
@@ -35,7 +34,9 @@
           .message__header.clearfix
             .message__header__name= message.user.name
             .message__header__date= message.created_at.strftime('%Y年%m月%d日 %H:%M')
-          .message__body= message.body
+          .message__body
+            %p= message.body
+            = image_tag(message.image)
     .footer
       .footer__chat
         = form_for(@message, html: {class: "message-form clearfix", id: "message-form"}, method: "post") do |f|

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -134,7 +134,7 @@ ja:
       carrierwave_processing_error: failed to be processed
       carrierwave_integrity_error: is not of an allowed file type
       carrierwave_download_error: could not be downloaded
-      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+      extension_whitelist_error: "%{extension}はアップロードできません。 アップロード可能なファイルは以下の形式です: %{allowed_types}"
       extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
       content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
       content_type_blacklist_error: "You are not allowed to upload %{content_type} files"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -130,6 +130,18 @@ ja:
       too_short: は%{count}文字以上で入力してください。
       wrong_length: は%{count}文字で入力してください。
       other_than: "は%{count}以外の値にしてください。"
+      # carrierwave error messages
+      carrierwave_processing_error: failed to be processed
+      carrierwave_integrity_error: is not of an allowed file type
+      carrierwave_download_error: could not be downloaded
+      extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+      extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+      content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
+      content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
+      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
+      mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
+      min_size_error: "File size should be greater than %{min_size}"
+      max_size_error: "File size should be less than %{max_size}"
     template:
       body: 次の項目を確認してください。
       header:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -107,7 +107,7 @@ ja:
     format: ! '%{attribute}%{message}'
     messages:
       accepted: を受諾してください。
-      blank: を入力してください。
+      blank: メッセージを入力してください。
       present: は入力しないでください。
       confirmation: と%{attribute}の入力が一致しません。
       empty: を入力してください。

--- a/db/migrate/20161021063451_add_image_to_messages.rb
+++ b/db/migrate/20161021063451_add_image_to_messages.rb
@@ -1,0 +1,5 @@
+class AddImageToMessages < ActiveRecord::Migration[5.0]
+  def change
+    add_column :messages, :image, :string, after: :body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161017104558) do
+ActiveRecord::Schema.define(version: 20161021063451) do
 
   create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20161017104558) do
     t.integer  "user_id",                  null: false
     t.integer  "group_id",                 null: false
     t.text     "body",       limit: 65535
+    t.string   "image"
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.index ["group_id"], name: "index_messages_on_group_id", using: :btree


### PR DESCRIPTION
# why
テキスト以外のものも投稿できるように

# what
- carrie wave のインストール
- uploaderの作成
- message model に imageカラムを追加
- メッセージ投稿のviewを調整
- メッセージ表示のviewを調整